### PR TITLE
Couple improvements to en_US.lang

### DIFF
--- a/assets/forestry/lang/en_US.lang
+++ b/assets/forestry/lang/en_US.lang
@@ -5,9 +5,6 @@
 death.engine.clockwork.player=%1$s was stabbed by a loose spring. %2$s was the negligent watchmaker.
 death.engine.clockwork=%1$s was stabbed by a loose spring.
 
-for.beverage.effect.alcoholic=Alcoholic
-for.beverage.effect.antidote=Antidote
-
 for.chat.cannotmemorizeagain=You already memorized this information.
 for.chat.memorizednote=You memorize the note and dispose of the crumpled scrap of paper.
 for.chat.memorizednote2=You feel more confident in your ability to breed %1$s with %2$s to make %3$s!
@@ -505,9 +502,6 @@ item.for.bee_combs.stringy.name=Stringy Comb
 item.for.bee_combs.wheaten.name=Wheaten Comb
 
 item.for.beeswax.name=Beeswax
-
-item.for.beverage.meadCurative.name=Curative Mead
-item.for.beverage.meadShort.name=Short Mead
 
 item.for.biome_finder.name=Habitat Locator
 item.for.bituminous_peat.name=Bituminous Peat
@@ -1660,7 +1654,7 @@ for.config.world.generate.beehives.dimBlacklist.comment=Disables the generation 
 for.config.world.generate.beehives.blacklist.category_comment=Disables the generation of a specific hive in a specific biome or in a biome with a specific biome type. Just add the registry name of the biome or the name of the biome type to the property of the hive. Every biome type / registry name has to be in a seperate line.
 
 for.config.world.generate.villagers=Generate Villagers
-for.config.world.generate.villagers.comment=Generates forestry villagers and their houses.
+for.config.world.generate.villagers.comment=Generates Forestry villagers and their houses.
 
 for.config.crafting=Crafting
 for.config.crafting.bronze=Craft Bronze
@@ -1690,7 +1684,7 @@ for.config.tweaks.gui.tooltip.liquidamount=Liquid Tooltip
 for.config.tweaks.gui.tooltip.liquidamount.comment=Display liquid amounts in tank tooltips.
 
 for.config.tweaks.permissions=Permissions
-for.config.tweaks.permissions.comment=Enables access restrictions on forestry machines.
+for.config.tweaks.permissions.comment=Enables access restrictions on Forestry machines.
 for.config.tweaks.version.check=Version Check
 for.config.tweaks.version.check.comment=Enables update and version check notice.
 
@@ -1702,9 +1696,9 @@ for.config.tweaks.farms.size.comment=Sets the size multiplier of the farmland.
 for.config.tweaks.farms.square=Square Farms
 for.config.tweaks.farms.square.comment=Makes farms use a square layout instead of a diamond one.
 for.config.tweaks.farms.enderlily=EnderLily Farm Support
-for.config.tweaks.farms.enderlily.comment=Enables farm support for ExtraUtilities Ender-lily seeds.
+for.config.tweaks.farms.enderlily.comment=Enables farm support for Extra Utilities Ender-lily seeds.
 for.config.tweaks.farms.redorchid=Red Orchid Farm Support
-for.config.tweaks.farms.redorchid.comment=Enables farm support for ExtraUtilities Red Orchid.
+for.config.tweaks.farms.redorchid.comment=Enables farm support for Extra Utilities Red Orchid.
 for.config.tweaks.farms.magicalcrops=Magical Crops Farm Support
 for.config.tweaks.farms.magicalcrops.comment=Enables farm support for Magical Crops.
 
@@ -1738,7 +1732,7 @@ for.config.structures=Structures
 for.config.structures.disabled=Disabled Structures
 for.config.structures.disabled.comment=List specific structures to disable them.
 
-for.config.farm.fertilizers.items=Add fertilizers to forestry. An entry have to looks like this modID:itemName:MetaData;fertilizerValue. You need to seperate every entry in a sererate line.
+for.config.farm.fertilizers.items=Add fertilizers to Forestry. An entry have to looks like this modID:itemName:MetaData;fertilizerValue. You need to separate every entry in a separate line.
 
 for.config.fluids=Fluids
 for.config.fluids.enable.format=Enables %s fluid.

--- a/assets/forestry/lang/en_US.lang
+++ b/assets/forestry/lang/en_US.lang
@@ -104,6 +104,7 @@ fluid.juice=Fruit Juice
 fluid.short.mead=Short Mead
 fluid.milk=Milk
 fluid.seed.oil=Seed Oil
+
 tile.forestry.fluid.bio.ethanol.name=Ethanol
 tile.forestry.fluid.biomass.name=Biomass
 tile.forestry.fluid.glass.name=Liquid Glass
@@ -130,7 +131,7 @@ for.gui.arid=Arid
 for.gui.beach=Beach
 
 for.gui.portablealyzer=Portable Genetic Analyzer
-for.gui.portablealyzer.help=Supply bee, tree, butterfly or an other individual and provide honey or honeydew as a pacifier.
+for.gui.portablealyzer.help=Supply bee, sapling, butterfly or an other individual and provide honey or honeydew as a pacifier.
 
 for.gui.beealyzer.artificial=Artificial Origin
 for.gui.beealyzer.behaviour=Behaviour
@@ -355,7 +356,7 @@ for.gui.camouflage_spray_can=Camouflage Spray Can
 
 for.hints.apiaristsuit.desc=A full apiarist's suit will protect you from all negative bee effects.
 for.hints.apiaristsuit.tag=Bee Suits!
-for.hints.beebiomes.desc=Bees only work in biomes that suit their species. Use your beealyzer and habitat locator to find out in which.
+for.hints.beebiomes.desc=Bees only work in biomes that suit their species. Use your portable analyzer and habitat locator to find out in which.
 for.hints.beebiomes.tag=Choose your biome!
 for.hints.beebreeding.desc=Crossbreeding drones and princesses of different species may net you offspring with a new species.
 for.hints.beebreeding.tag=Breed your bees!
@@ -378,7 +379,7 @@ for.hints.enginebronzeheatloss.tag=Careful with water!
 for.hints.enginebronzeoutput.desc=Different fuels will net you different energy outputs in a biogas engine. Outputs range from 10 RF/t to 50 RF/t.
 for.hints.enginebronzeoutput.tag=Choose your fuel!
 for.hints.enginebronzewaste.desc=Contrary to peat-fired engines disabled biogas engines will not waste the biomass currently in the system.
-for.hints.enginebronzewaste.tag=Fuel is conserved.
+for.hints.enginebronzewaste.tag=Fuel is conserved
 for.hints.enginecopperfuels.desc=Peat-fired engines can use untreated peat, but they can also use bituminous peat to double their energy output.
 for.hints.enginecopperfuels.tag=Use all the fuels!
 for.hints.enginecopperwaste.desc=Disabled peat-fired engines continue to burn peat already removed from the stash without generating energy from it.
@@ -570,7 +571,7 @@ item.for.hardened_machine.name=Hardened Casing
 item.for.honeydew.name=Honeydew
 
 item.for.portable_alyzer.name=Portable Analyzer
-item.for.portable_alyzer.tooltip=Handheld Genetic Analyzer for bees, trees, and butterflies.
+item.for.portable_alyzer.tooltip=Handheld Genetic Analyzer for bees, saplings, and butterflies.
 
 item.for.honey_drop.charged.name=Charged Drop
 item.for.honey_drop.honey.name=Honey Drop
@@ -665,11 +666,11 @@ item.for.wrench.tooltip=Shift-Use to rotate blocks.
 
 item.for.camouflage_spray_can.name=Camouflage Spray Can
 
-itemGroup.apiculture=Apiculture
-itemGroup.arboriculture=Arboriculture
+itemGroup.apiculture=Forestry Apiculture
+itemGroup.arboriculture=Forestry Arboriculture
 itemGroup.forestry=Forestry
-itemGroup.lepidopterology=Lepidopterology
-itemGroup.agriculture=Agriculture
+itemGroup.lepidopterology=Forestry Lepidopterology
+itemGroup.agriculture=Forestry Agriculture
 
 tile.for.analyzer.name=Analyzer
 tile.for.escritoire.name=Escritoire
@@ -765,7 +766,7 @@ for.errors.is_raining.help=Only tolerant fliers can work in the rain.
 for.errors.no_drone.desc=No drone
 for.errors.no_drone.help=Mating requires a drone present.
 for.errors.no_flower.desc=No flowers
-for.errors.no_flower.help=Hive members are not finding the right flowers. Use the Beealyzer to learn their flower preference.
+for.errors.no_flower.help=Hive members are not finding the right flowers. Use the portable analyzer to learn their flower preference.
 for.errors.no_queen.desc=No queen
 for.errors.no_queen.help=Supply this hive with a queen or a princess and a drone.
 for.errors.no_sky.desc=Sky obstructed
@@ -1448,7 +1449,7 @@ for.message.greenhouse_screen.preview.active=Switched preview mod to active
 for.message.greenhouse_screen.preview.inactive=Switched preview mod to inactive
 for.message.greenhouse_screen.center=You have set the center of the greenhouse to the coordinates
 for.message.greenhouse_screen.away=You are too far away from the greenhouse to use this item
-for.message.greenhouse_screen.notassembled=You only can like this item to the an assembled greenhouse
+for.message.greenhouse_screen.notassembled=You only can link this item to the an assembled greenhouse
 
 for.greenhouse_screen.mode=Preview Mode: %s
 for.greenhouse_screen.mode.active=Active
@@ -1601,30 +1602,30 @@ for.module.crates.description=Adds crates.
 for.module.greenhouse.description=Adds a greenhouse multiblock.
 for.module.database.description=Adds a new storage block for bees / trees and butterflies.
 
-for.module.buildcraft6.description=Compatibility plugin for BuildCraft 6.
+for.module.buildcraft6.description=Compatibility module for BuildCraft 6.
 for.module.pipes.description=Adds the apiarist's pipe for beekeeping if apiculture is enabled and BuildCraft 6 is present.
-for.module.ic2.description=Compatibility plugin for IC2. Adds electrical engine and generator for power conversion.
-for.module.natura.description=Compatibility plugin for Natura. Enables farming Natura saplings.
-for.module.ee2.description=Compatibility plugin for Equivalent Exchange 2. Enables the Omega branch of bees. Requires Apiculture to be enabled.
-for.module.ee3.description=Compatibility plugin for Equivalent Exchange 3.
+for.module.ic2.description=Compatibility module for IC2. Adds electrical engine and generator for power conversion.
+for.module.natura.description=Compatibility module for Natura. Enables farming Natura saplings.
+for.module.ee2.description=Compatibility module for Equivalent Exchange 2. Enables the Omega branch of bees. Requires Apiculture to be enabled.
+for.module.ee3.description=Compatibility module for Equivalent Exchange 3.
 for.module.farmcraftory.description=Enables compatibility with FarmCraftory. Adds crops and vegetables to farms.
-for.module.biomesoplenty.description=Compatibility plugin for Biomes O Plenty. Enables farming BoP saplings.
-for.module.extrautilities.description=Compatibility plugin for Extra Utilities. Enables farming ender lilies and red orchid.
-for.module.harvestcraft.description=Compatibility plugin for HarvestCraft. Enables farming HarvestCraft plants and trees.
-for.module.magicalcrops.description=Compatibility plugin for Magical Crops.
-for.module.chisel.description=Compatibility plugin for Chisel. Adds worldgen blocks to Backpacks.
-for.module.plantmegapack.description=Compatibility plugin for Plant Mega Pack.
-for.module.witchery.description=Compatibility plugin for Witchery.
-for.module.agricraft.description=Compatibility plugin for AgriCraft.
-for.module.enderIO.description=Compatibility plugin for EnderIO.
-for.module.immersiveengineering.description=Compatibility plugin for Immersive Engineering.
-for.module.growthcraft.description=Compatibility plugin for GrowthCraft.
-for.module.erebus.description=Compatibility plugin for Erebus.
-for.module.rotarycraft.description=Compatibility plugin for RotaryCraft.
-for.module.actuallyadditions.description=Compatibility plugin for Actually Additions.
-for.module.roots.description=Compatibility plugin for Roots.
-for.module.rustic.description=Compatibility plugin for Rustic.
-for.module.mysticalagriculture.description=Compatibility plugin for Mystical Agriculture. Enables farming Mystical Agriculture crops.
+for.module.biomesoplenty.description=Compatibility module for Biomes O Plenty. Enables farming BoP saplings.
+for.module.extrautilities.description=Compatibility module for Extra Utilities. Enables farming ender lilies and red orchid.
+for.module.harvestcraft.description=Compatibility module for HarvestCraft. Enables farming HarvestCraft plants and trees.
+for.module.magicalcrops.description=Compatibility module for Magical Crops.
+for.module.chisel.description=Compatibility module for Chisel. Adds worldgen blocks to Backpacks.
+for.module.plantmegapack.description=Compatibility module for Plant Mega Pack.
+for.module.witchery.description=Compatibility module for Witchery.
+for.module.agricraft.description=Compatibility module for AgriCraft.
+for.module.enderIO.description=Compatibility module for EnderIO.
+for.module.immersiveengineering.description=Compatibility module for Immersive Engineering.
+for.module.growthcraft.description=Compatibility module for GrowthCraft.
+for.module.erebus.description=Compatibility module for Erebus.
+for.module.rotarycraft.description=Compatibility module for RotaryCraft.
+for.module.actuallyadditions.description=Compatibility module for Actually Additions.
+for.module.roots.description=Compatibility module for Roots.
+for.module.rustic.description=Compatibility module for Rustic.
+for.module.mysticalagriculture.description=Compatibility module for Mystical Agriculture. Enables farming Mystical Agriculture crops.
 
 ####################
 # CONFIG FILES


### PR DESCRIPTION
Replaced tree with sapling in analyzer (there is no tree item, only saplings and wood) It also says "or an other individual" which can mean *some* tree related thing.
Replaced beealyzer with portable analyzer (pretty straight-forward)
Changed plugin references to module ones
Forestry item groups in creative modified to have mod name in it (It's sometimes hard to find out which mod added this tab especially using other language file) Other multi-itemgroup mods doing this too btw.
Fixed typo like -> link
Dot removed from line 382 for consistency with other tag lines
Doing this as PR so you guys can review it first 😄  (It was a long break btw)
